### PR TITLE
Honor attribute readonly when checking if TextArea.isEditable.

### DIFF
--- a/webdriver/src/main/java/org/popper/fw/webdriver/elements/impl/TextArea.java
+++ b/webdriver/src/main/java/org/popper/fw/webdriver/elements/impl/TextArea.java
@@ -66,4 +66,13 @@ public class TextArea extends AbstractInput implements IWebTextBox {
 	public String getText() {
 		return getElement().getAttribute("value");
 	}
+
+	@Override
+	public boolean isEditable() {
+		return super.isEditable() && !isReadonly();
+	}
+	
+	public boolean isReadonly() {
+		return getAttribute("readonly") != null;
+	}
 }


### PR DESCRIPTION
Closes #12.