### PR TITLE
use the general SearchContext instead of a WebElement

### DIFF
--- a/webdriver/src/main/java/org/popper/fw/webdriver/WebdriverFactory.java
+++ b/webdriver/src/main/java/org/popper/fw/webdriver/WebdriverFactory.java
@@ -51,9 +51,9 @@ public class WebdriverFactory implements IPoFactory {
 	}
 
 	public <T extends Object> T createPo(Class<T> type, String name, By by,
-			PageObjectImplementation parent, WebElement webElement) {
+			PageObjectImplementation parent, SearchContext searchContext) {
 		PageObjectImplementation poi = WebdriverPageObjectHelper.createPageObjectImplementation(type, by, name, parent, context,
-					webElement);
+					searchContext);
 		
 		return createProxy(type, poi);
 	}

--- a/webdriver/src/main/java/org/popper/fw/webdriver/WebdriverPageObjectHelper.java
+++ b/webdriver/src/main/java/org/popper/fw/webdriver/WebdriverPageObjectHelper.java
@@ -24,9 +24,9 @@ import org.popper.fw.webdriver.annotations.Frame.FramePoExtension;
 
 public class WebdriverPageObjectHelper {
 	public static PageObjectImplementation createPageObjectImplementation(Class<?> basicClass, By searchContextBy, String name,
-			PageObjectImplementation parent, WebdriverContext context, WebElement webElement) {
+			PageObjectImplementation parent, WebdriverContext context, SearchContext searchContext) {
 		PageObjectImplementation poi = new PageObjectImplementation(context, basicClass, name, parent);
-		poi.addExtension(new WebdriverPoExtension(context, webElement, searchContextBy));
+		poi.addExtension(new WebdriverPoExtension(context, searchContext, searchContextBy));
 		
 		return poi;
 	}
@@ -35,8 +35,8 @@ public class WebdriverPageObjectHelper {
 		openFrame(poi);
 		
 		WebdriverPoExtension ext = poi.getExtension(WebdriverPoExtension.class);
-		if (ext.webElement != null) {
-			return ext.webElement;
+		if (ext.searchContext != null) {
+			return ext.searchContext;
 		}
 
 		if (poi.getParent() == null || ext.searchContextBy == null) {
@@ -68,14 +68,14 @@ public class WebdriverPageObjectHelper {
 	public static class WebdriverPoExtension {
 		public final WebdriverContext context;
 
-		public final WebElement webElement;
+		public final SearchContext searchContext;
 		
 		public final By searchContextBy;
 
-		protected WebdriverPoExtension(WebdriverContext context, WebElement webElement, By searchContextBy) {
+		protected WebdriverPoExtension(WebdriverContext context, SearchContext searchContext, By searchContextBy) {
 			super();
 			this.context = context;
-			this.webElement = webElement;
+			this.searchContext = searchContext;
 			this.searchContextBy = searchContextBy;
 		}
 	}


### PR DESCRIPTION
Currently a WebElement is used to create page objects, but only a SearchContext is needed.
That will be compatible with the new ShadowRoot object introduced by Selenium, which is a SearchContext but no WebElement